### PR TITLE
Fixing one pmem path on AppDirect mode may cause the pmem initialization path to be empty Path

### DIFF
--- a/src/main/scala/org/apache/spark/storage/BlockManager.scala
+++ b/src/main/scala/org/apache/spark/storage/BlockManager.scala
@@ -194,9 +194,13 @@ private[spark] class BlockManager(
       if (numaNodeId == -1) {
         numaNodeId = executorId.toInt
       }
-      val path = pmemInitialPaths(numaNodeId % 2)
-      val initPath = path + File.separator + s"executor_${executorId}" + File.pathSeparator
-      val file = new File(initPath)
+      val path_postfix = File.separator + s"executor_${executorId}" + File.pathSeparator
+      var file  = if (1 == pmemInitialPaths.size) {
+        new File(pmemInitialPaths(0) + path_postfix)
+      } else {
+        new File(pmemInitialPaths(numaNodeId % 2) + path_postfix)
+      }
+        
       if (file.exists() && file.isFile) {
         file.delete()
       }


### PR DESCRIPTION
## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)


## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)


(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

